### PR TITLE
change host to domain because maybe host is overriden?

### DIFF
--- a/src/Middleware/SendRequestDatadogMetric.php
+++ b/src/Middleware/SendRequestDatadogMetric.php
@@ -33,7 +33,7 @@ class SendRequestDatadogMetric
             'app' => config('datadog-laravel-metric.tags.app'),
             'environment' => config('datadog-laravel-metric.tags.env'),
             'action' => $action,
-            'host' => $request->getHost(),
+            'domain' => $request->getHost(),
             'status_code' => $response?->getStatusCode() ?? 500,
         ];
 

--- a/tests/Middleware/SendRequestDatadogMetricTest.php
+++ b/tests/Middleware/SendRequestDatadogMetricTest.php
@@ -41,7 +41,7 @@ it('sends metric data to datadog and exclude tag as configured', function () {
                 'app' => 'testing-app',
                 'environment' => 'testing',
                 'action' => 'unknownController@unknownMethod',
-                'host' => '',
+                'domain' => '',
             ]
         )
         ->once();


### PR DESCRIPTION
smh should have not overriden `host`

https://docs.datadoghq.com/metrics/custom_metrics/dogstatsd_metrics_submission/#host-tag

> [Host tag](https://docs.datadoghq.com/metrics/custom_metrics/dogstatsd_metrics_submission/#host-tag)
> 
> The host tag is assigned automatically by the Datadog Agent aggregating the metrics. Metrics submitted with a host tag not matching the Agent hostname lose reference to the original host. The submitted host tag overrides any hostname collected by or configured in the Agent.
> 


after changes

![image](https://github.com/mamitech/datadog-laravel-metric/assets/4879281/864f3d20-864f-48b6-8994-13b082408396)

