### PR TITLE
add transformer configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,15 @@ List of possible tags (by default those tags are sent as metric data):
 - host
 - status_code
 
+### 'tag_transformers'
+
+On the Middleware, you can transform (modify) array of tags before it's sent to datadog.
+To do that, you have to write your own class in your Laravel app and 
+`implements \Mamitech\DatadogLaravelMetric\TagTransformer`.
+
+Then, put the class names inside the array. For example, please refer to class `TransformerForTest`
+inside `tests/Middleware/SendRequestDatadogMetricTest.php`.
+
 ## ENV value
 
 As mentioned in config file, these are the ENV values that can be set for configuration

--- a/config/datadog-laravel-metric.php
+++ b/config/datadog-laravel-metric.php
@@ -26,8 +26,8 @@ return [
         // list of possible tags: app,environment,action,host,status_code
         'exclude_tags' => explode(',', env('DATADOG_MIDDLEWARE_EXCLUDE_TAGS', '')),
 
-        'tag_transformer' => [
-            // list of classes that implement Mamitech\DatadogLaravelMetric\TagTransformer
+        'tag_transformers' => [
+            // list of classes that implements Mamitech\DatadogLaravelMetric\TagTransformer
             // example: \App\Datadog\AddHostTagTransformer
         ],
     ],

--- a/config/datadog-laravel-metric.php
+++ b/config/datadog-laravel-metric.php
@@ -25,5 +25,10 @@ return [
         // put them in a comma separated string.
         // list of possible tags: app,environment,action,host,status_code
         'exclude_tags' => explode(',', env('DATADOG_MIDDLEWARE_EXCLUDE_TAGS', '')),
+
+        'tag_transformer' => [
+            // list of classes that implement Mamitech\DatadogLaravelMetric\TagTransformer
+            // example: Mamitech\DatadogLaravelMetric\TagTransformer\ReplaceTagTransformer
+        ],
     ],
 ];

--- a/config/datadog-laravel-metric.php
+++ b/config/datadog-laravel-metric.php
@@ -28,7 +28,7 @@ return [
 
         'tag_transformer' => [
             // list of classes that implement Mamitech\DatadogLaravelMetric\TagTransformer
-            // example: Mamitech\DatadogLaravelMetric\TagTransformer\ReplaceTagTransformer
+            // example: \App\Datadog\AddHostTagTransformer
         ],
     ],
 ];

--- a/src/Middleware/SendRequestDatadogMetric.php
+++ b/src/Middleware/SendRequestDatadogMetric.php
@@ -44,7 +44,7 @@ class SendRequestDatadogMetric
             unset($tags[$excludeTag]);
         }
 
-        $tagTransformers = config('datadog-laravel-metric.middleware.tag_transformer');
+        $tagTransformers = config('datadog-laravel-metric.middleware.tag_transformers');
         // check if $tagTransformers is an array
         if (is_array($tagTransformers)) {
             foreach ($tagTransformers as $transClass) {

--- a/src/Middleware/SendRequestDatadogMetric.php
+++ b/src/Middleware/SendRequestDatadogMetric.php
@@ -5,6 +5,7 @@ namespace Mamitech\DatadogLaravelMetric\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use Mamitech\DatadogLaravelMetric\DatadogLaravelMetric;
+use Mamitech\DatadogLaravelMetric\TagTransformer;
 
 class SendRequestDatadogMetric
 {
@@ -48,6 +49,9 @@ class SendRequestDatadogMetric
         if (is_array($tagTransformers)) {
             foreach ($tagTransformers as $transClass) {
                 $transformer = app($transClass);
+                if (! $transformer instanceof TagTransformer) {
+                    throw new \Exception("Class $transClass must implement Mamitech\DatadogLaravelMetric\TagTransformer");
+                }
                 $tags = $transformer->transform($tags);
             }
         }

--- a/src/Middleware/SendRequestDatadogMetric.php
+++ b/src/Middleware/SendRequestDatadogMetric.php
@@ -43,6 +43,15 @@ class SendRequestDatadogMetric
             unset($tags[$excludeTag]);
         }
 
+        $tagTransformers = config('datadog-laravel-metric.middleware.tag_transformer');
+        // check if $tagTransformers is an array
+        if (is_array($tagTransformers)) {
+            foreach ($tagTransformers as $transClass) {
+                $transformer = app($transClass);
+                $tags = $transformer->transform($tags);
+            }
+        }
+
         // send to Datadog
         $metricName = config('datadog-laravel-metric.middleware.metric_name');
         $this->datadogLaravelMetric->measure($metricName, $tags, $duration);

--- a/src/TagTransformer.php
+++ b/src/TagTransformer.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Mamitech\DatadogLaravelMetric;
+
 interface TagTransformer
 {
     // transform tags and return the new modified tags

--- a/src/TagTransformer.php
+++ b/src/TagTransformer.php
@@ -1,0 +1,7 @@
+<?php
+
+interface TagTransformer
+{
+    // transform tags and return the new modified tags
+    public function transform(array $tags): array;
+}

--- a/tests/Middleware/SendRequestDatadogMetricTest.php
+++ b/tests/Middleware/SendRequestDatadogMetricTest.php
@@ -91,7 +91,7 @@ it('transform the tag when transformer exists', function() {
         'datadog-laravel-metric.enabled' => true,
         'datadog-laravel-metric.tags.app' => 'testing-app',
         'datadog-laravel-metric.tags.environment' => 'testing',
-        'datadog-laravel-metric.middleware.tag_transformer' => [TransformerForTest::class]
+        'datadog-laravel-metric.middleware.tag_transformers' => [TransformerForTest::class]
     ]);
 
     $mockDatadog = Mockery::mock(DogStatsd::class);

--- a/tests/Middleware/SendRequestDatadogMetricTest.php
+++ b/tests/Middleware/SendRequestDatadogMetricTest.php
@@ -78,8 +78,8 @@ it('does not send metric data to datadog when disabled', function () {
     expect($expectedResponse === $response)->toBeTrue();
 });
 
-class TransformerForTest {
-    public function transform(array $data) {
+class TransformerForTest implements \Mamitech\DatadogLaravelMetric\TagTransformer {
+    public function transform(array $data): array {
         $data['app'] = 'modified';
         unset($data['environment']);
         return $data;

--- a/tests/Middleware/SendRequestDatadogMetricTest.php
+++ b/tests/Middleware/SendRequestDatadogMetricTest.php
@@ -77,3 +77,47 @@ it('does not send metric data to datadog when disabled', function () {
 
     expect($expectedResponse === $response)->toBeTrue();
 });
+
+class TransformerForTest {
+    public function transform(array $data) {
+        $data['app'] = 'modified';
+        unset($data['environment']);
+        return $data;
+    }
+}
+
+it('transform the tag when transformer exists', function() {
+    config([
+        'datadog-laravel-metric.enabled' => true,
+        'datadog-laravel-metric.tags.app' => 'testing-app',
+        'datadog-laravel-metric.tags.environment' => 'testing',
+        'datadog-laravel-metric.middleware.tag_transformer' => [TransformerForTest::class]
+    ]);
+
+    $mockDatadog = Mockery::mock(DogStatsd::class);
+    $mockDatadog->shouldReceive('microtiming')
+    ->with(
+        'request',
+        Mockery::any(),
+        1,
+        [
+            'app' => 'modified',
+            'action' => 'unknownController@unknownMethod',
+            'domain' => '',
+            'status_code' => 200
+        ]
+    )
+    ->once();
+    $datadogLaravelMetric = new DatadogLaravelMetric($mockDatadog);
+
+    $sampleRequestMiddleware = new SendRequestDatadogMetric($datadogLaravelMetric);
+    $expectedResponse = new Response();
+    $response = $sampleRequestMiddleware->handle(
+        new Request(),
+        static function () use ($expectedResponse) {
+            return $expectedResponse;
+        }
+    );
+
+    expect($expectedResponse === $response)->toBeTrue();
+});


### PR DESCRIPTION
# Unwanted EC2 related tags

Currently we have problem in datadog that our custom metric has unwanted tags that is related to `ec2` such as `security-group`, `instance-type`, etc., increasing our cost for the custom metric.

![image](https://github.com/mamitech/datadog-laravel-metric/assets/3351656/8008bf1b-1c8c-4308-a03c-f16d2105ed13)

After long struggling of looking into the solution of how to remove those tags, we can't find configuration to remove it from datadog agent / dogstatsd. Eventually, mas Fahri found that these tags is automatically added by datadog agent when the `host` tag on the metric match the `host` tag on the machine ([see datadog documentation on custom metric](https://docs.datadoghq.com/metrics/custom_metrics/dogstatsd_metrics_submission/#host-tag)).

Hence, we think that if we can override the `host` tag to be intentionally not matching host name in the machine, we can avoid those tags. Also considering that before 10 october when we accidentally override this `host` tag to be `domain`, we don't have those other additional tags back then.

# Adding tag transformer into configuration

In this Pull Request I added one more key to the config file: `tag-transformers`. In this key, the user of the library could add the list of class names that they can use to transform the `tags` before it is sent to Datadog.