### PR TITLE
CBE-724 handle 'as' and no route become unknowncontroller

### DIFF
--- a/config/datadog-laravel-metric.php
+++ b/config/datadog-laravel-metric.php
@@ -16,8 +16,8 @@ return [
         'metric_prefix' => env('DATADOG_METRIC_PREFIX'),
     ],
     'tags' => [
-        'app' => env('DATADOG_TAGS_APP') ?? config('app.name'),
-        'env' => env('DATADOG_TAGS_ENV') ?? config('app.env'),
+        'app' => env('DATADOG_TAGS_APP', env('APP_NAME', 'Laravel')),
+        'env' => env('DATADOG_TAGS_ENV', env('APP_ENV', 'production')),
     ],
     'middleware' => [
         'metric_name' => env('DATADOG_MIDDLEWARE_METRIC_NAME', 'request'),

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,7 +5,6 @@ parameters:
     level: 4
     paths:
         - src
-        - config
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,4 +9,3 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false

--- a/src/Middleware/SendRequestDatadogMetric.php
+++ b/src/Middleware/SendRequestDatadogMetric.php
@@ -31,13 +31,14 @@ class SendRequestDatadogMetric
         $duration = microtime(true) - $metricStartTime;
 
         // tags get request controller name, action, and request method and status code
-        $action = $this->resolveAction($request);
+        $statusCode = $response?->getStatusCode() ?? 500;
+        $action = $this->resolveAction($request, $statusCode);
         $tags = [
             'app' => config('datadog-laravel-metric.tags.app'),
             'environment' => config('datadog-laravel-metric.tags.env'),
             'action' => $action,
             'domain' => $request->getHost(),
-            'status_code' => $response?->getStatusCode() ?? 500,
+            'status_code' => $statusCode,
         ];
 
         // exclude certain tags from being sent to datadog
@@ -68,12 +69,18 @@ class SendRequestDatadogMetric
     /**
      * Resolve the action name from the request route.
      */
-    private function resolveAction(Request $request): string
+    private function resolveAction(Request $request, int $statusCode): string
     {
         $route = $request->route();
 
         if ($route === null) {
-            return self::DEFAULT_ACTION;
+            return match ($statusCode) {
+                404 => 'NoRouteMatched@404',
+                405 => 'MethodNotAllowed@405',
+                500 => 'ServerError@500',
+                503 => 'MaintenanceMode@503',
+                default => 'response@'.$statusCode,
+            };
         }
 
         $routeAction = $route->getAction();
@@ -106,6 +113,11 @@ class SendRequestDatadogMetric
             if (is_object($uses) && method_exists($uses, '__invoke')) {
                 return get_class($uses).'@__invoke';
             }
+        }
+
+        // Case 3: Route name as fallback (e.g., Route::view(), Route::redirect())
+        if (isset($routeAction['as']) && is_string($routeAction['as'])) {
+            return 'name@'.$routeAction['as'];
         }
 
         return self::DEFAULT_ACTION;

--- a/tests/Middleware/SendRequestDatadogMetricTest.php
+++ b/tests/Middleware/SendRequestDatadogMetricTest.php
@@ -252,7 +252,7 @@ it('resolves action as unknownController@unknownMethod when route has no action'
     expect($expectedResponse === $response)->toBeTrue();
 });
 
-it('resolves action as unknownController@unknownMethod when route is null', function () {
+it('resolves action as response@statusCode when route is null', function () {
     config(['datadog-laravel-metric.enabled' => true]);
     config(['datadog-laravel-metric.tags.app' => 'testing-app']);
     config(['datadog-laravel-metric.tags.env' => 'testing']);
@@ -264,7 +264,7 @@ it('resolves action as unknownController@unknownMethod when route is null', func
             Mockery::any(),
             1,
             Mockery::on(function ($tags) {
-                return $tags['action'] === 'unknownController@unknownMethod';
+                return $tags['action'] === 'response@200';
             })
         )
         ->once();
@@ -275,6 +275,135 @@ it('resolves action as unknownController@unknownMethod when route is null', func
 
     $sampleRequestMiddleware = new SendRequestDatadogMetric($datadogLaravelMetric);
     $expectedResponse = new Response;
+    $response = $sampleRequestMiddleware->handle(
+        $request,
+        static function () use ($expectedResponse) {
+            return $expectedResponse;
+        }
+    );
+
+    expect($expectedResponse === $response)->toBeTrue();
+});
+
+it('resolves action as NoRouteMatched@404 when route is null and status is 404', function () {
+    config(['datadog-laravel-metric.enabled' => true]);
+    config(['datadog-laravel-metric.tags.app' => 'testing-app']);
+    config(['datadog-laravel-metric.tags.env' => 'testing']);
+
+    $mockDatadog = Mockery::mock(DogStatsd::class);
+    $mockDatadog->shouldReceive('microtiming')
+        ->with(
+            'request',
+            Mockery::any(),
+            1,
+            Mockery::on(function ($tags) {
+                return $tags['action'] === 'NoRouteMatched@404';
+            })
+        )
+        ->once();
+    $datadogLaravelMetric = new DatadogLaravelMetric($mockDatadog);
+
+    $request = new Request;
+    // No route set - route() returns null
+
+    $sampleRequestMiddleware = new SendRequestDatadogMetric($datadogLaravelMetric);
+    $expectedResponse = new Response('', 404);
+    $response = $sampleRequestMiddleware->handle(
+        $request,
+        static function () use ($expectedResponse) {
+            return $expectedResponse;
+        }
+    );
+
+    expect($expectedResponse === $response)->toBeTrue();
+});
+
+it('resolves action as MethodNotAllowed@405 when route is null and status is 405', function () {
+    config(['datadog-laravel-metric.enabled' => true]);
+    config(['datadog-laravel-metric.tags.app' => 'testing-app']);
+    config(['datadog-laravel-metric.tags.env' => 'testing']);
+
+    $mockDatadog = Mockery::mock(DogStatsd::class);
+    $mockDatadog->shouldReceive('microtiming')
+        ->with(
+            'request',
+            Mockery::any(),
+            1,
+            Mockery::on(function ($tags) {
+                return $tags['action'] === 'MethodNotAllowed@405';
+            })
+        )
+        ->once();
+    $datadogLaravelMetric = new DatadogLaravelMetric($mockDatadog);
+
+    $request = new Request;
+
+    $sampleRequestMiddleware = new SendRequestDatadogMetric($datadogLaravelMetric);
+    $expectedResponse = new Response('', 405);
+    $response = $sampleRequestMiddleware->handle(
+        $request,
+        static function () use ($expectedResponse) {
+            return $expectedResponse;
+        }
+    );
+
+    expect($expectedResponse === $response)->toBeTrue();
+});
+
+it('resolves action as ServerError@500 when route is null and status is 500', function () {
+    config(['datadog-laravel-metric.enabled' => true]);
+    config(['datadog-laravel-metric.tags.app' => 'testing-app']);
+    config(['datadog-laravel-metric.tags.env' => 'testing']);
+
+    $mockDatadog = Mockery::mock(DogStatsd::class);
+    $mockDatadog->shouldReceive('microtiming')
+        ->with(
+            'request',
+            Mockery::any(),
+            1,
+            Mockery::on(function ($tags) {
+                return $tags['action'] === 'ServerError@500';
+            })
+        )
+        ->once();
+    $datadogLaravelMetric = new DatadogLaravelMetric($mockDatadog);
+
+    $request = new Request;
+
+    $sampleRequestMiddleware = new SendRequestDatadogMetric($datadogLaravelMetric);
+    $expectedResponse = new Response('', 500);
+    $response = $sampleRequestMiddleware->handle(
+        $request,
+        static function () use ($expectedResponse) {
+            return $expectedResponse;
+        }
+    );
+
+    expect($expectedResponse === $response)->toBeTrue();
+});
+
+it('resolves action as MaintenanceMode@503 when route is null and status is 503', function () {
+    config(['datadog-laravel-metric.enabled' => true]);
+    config(['datadog-laravel-metric.tags.app' => 'testing-app']);
+    config(['datadog-laravel-metric.tags.env' => 'testing']);
+
+    $mockDatadog = Mockery::mock(DogStatsd::class);
+    $mockDatadog->shouldReceive('microtiming')
+        ->with(
+            'request',
+            Mockery::any(),
+            1,
+            Mockery::on(function ($tags) {
+                return $tags['action'] === 'MaintenanceMode@503';
+            })
+        )
+        ->once();
+    $datadogLaravelMetric = new DatadogLaravelMetric($mockDatadog);
+
+    $request = new Request;
+
+    $sampleRequestMiddleware = new SendRequestDatadogMetric($datadogLaravelMetric);
+    $expectedResponse = new Response('', 503);
     $response = $sampleRequestMiddleware->handle(
         $request,
         static function () use ($expectedResponse) {
@@ -320,7 +449,7 @@ it('resolves action from invokable object', function () {
     expect($expectedResponse === $response)->toBeTrue();
 });
 
-it('resolves action as unknownController@unknownMethod when route has only route name', function () {
+it('resolves action from route name when route has only route name', function () {
     config(['datadog-laravel-metric.enabled' => true]);
     config(['datadog-laravel-metric.tags.app' => 'testing-app']);
     config(['datadog-laravel-metric.tags.env' => 'testing']);
@@ -332,7 +461,7 @@ it('resolves action as unknownController@unknownMethod when route has only route
             Mockery::any(),
             1,
             Mockery::on(function ($tags) {
-                return $tags['action'] === 'unknownController@unknownMethod';
+                return $tags['action'] === 'name@api.users.index';
             })
         )
         ->once();

--- a/tests/Middleware/SendRequestDatadogMetricTest.php
+++ b/tests/Middleware/SendRequestDatadogMetricTest.php
@@ -41,7 +41,7 @@ it('sends metric data to datadog and exclude tag as configured', function () {
             [
                 'app' => 'testing-app',
                 'environment' => 'testing',
-                'action' => 'unknownController@unknownMethod',
+                'action' => 'response@200',
                 'domain' => '',
             ]
         )
@@ -518,7 +518,7 @@ it('transform the tag when transformer exists', function () {
             1,
             [
                 'app' => 'modified',
-                'action' => 'unknownController@unknownMethod',
+                'action' => 'response@200',
                 'domain' => '',
                 'status_code' => 200,
             ]


### PR DESCRIPTION
- Modify `resolveAction()` method that add handler for:
  - Route using 'as' style
  - No route found, fallback to read the status code